### PR TITLE
fix: 로그아웃 후 세션 초기화 및 채팅 내역 클린

### DIFF
--- a/unigo/templates/unigo_app/logout.html
+++ b/unigo/templates/unigo_app/logout.html
@@ -1,0 +1,22 @@
+{% load static %}
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Logging out...</title>
+  </head>
+  <body>
+    <p>로그아웃 중입니다...</p>
+    <script>
+      try {
+        sessionStorage.removeItem('unigo.app.chatHistory');
+        sessionStorage.removeItem('unigo.app.onboarding');
+        sessionStorage.removeItem('unigo.app.resultPanel');
+      } catch (e) {
+        console.warn('Failed to clear sessionStorage on logout page', e);
+      }
+      window.location.href = "{% url 'unigo_app:auth' %}";
+    </script>
+  </body>
+</html>

--- a/unigo/unigo_app/views.py
+++ b/unigo/unigo_app/views.py
@@ -175,8 +175,11 @@ def logout_view(request):
     """
     로그아웃 뷰 (GET 요청 처리 및 리다이렉트)
     """
+    # 로그아웃 처리 후 클라이언트 세션 스토리지를 정리할 수 있도록
+    # 로그아웃 완료 페이지를 렌더링하여 브라우저에서 sessionStorage를 초기화하고
+    # 클라이언트를 인증 페이지로 리다이렉트하게 한다.
     logout(request)
-    return redirect("unigo_app:auth")
+    return render(request, "unigo_app/logout.html")
 
 
 def auth_me(request):


### PR DESCRIPTION
# ⚠️ 중요 안내
**이슈를 먼저 생성하지 않고 Pull Request(PR)를 만들지 마세요.**  
모든 변경 사항은 PR을 열기 전에 반드시 논의가 필요합니다.  
이를 지키지 않을 경우 PR이 거절될 수 있습니다.

---

# 📌 변경 사항 설명
로그아웃 시 클라이언트 측 sessionStorage가 초기화되지 않아 비로그인 상태에서 이전 사용자 채팅 내역이 노출되거나 재로그인 시 duplicate entry 오류 발생
- 로그아웃 처리 후 “로그아웃 완료 페이지”를 렌더링하도록 수정
  - 해당 페이지에서 브라우저의 sessionStorage를 전체 초기화
  - 초기화 완료 후 인증로그인 페이지로 자동 리다이렉트

---

# 🧪 테스트 계획 (필수)
- 로그아웃 → 비로그인 채팅 화면 진입
  - 이전 사용자 채팅 내역이 표시되지 않는지 확인
- 로그아웃 → 동일 계정 재로그인 후 채팅
  - duplicate entry 오류가 발생하지 않는지 확인

---

# 🔗 관련 이슈
closes #16 